### PR TITLE
Run tests on appveyor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+branch = True
+source = ipykernel
+
+[report]
+omit = *test*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - python: "C:/Python27-x64"
       sdkver: "v7.0"
 
-    - python: "C:/Python27-x64"
+    - python: "C:/Python27"
       sdkver: "v7.0"
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,8 @@ environment:
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache
 
-matix:
-  fast_finish: True
+matrix:
+  fast_finish: true
 
 init:
   - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:path

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,27 +9,26 @@ environment:
 
   matrix:
     - python: "C:/Python27-x64"
-      sdkver: "v7.0"
-
     - python: "C:/Python27"
-      sdkver: "v7.0"
-
     - python: "C:/Python34-x64"
-      sdkver: "v7.1"
-
     - python: "C:/Python34"
-      sdkver: "v7.1"
+    - python: "C:/Python35-x64"
+    - python: "C:/Python35"
 
 matrix:
   allow_failures:
-  -  sdkver: "v7.0"
+    - python: "C:/Python27-x64"
+    - python: "C:/Python27"
+    - python: "C:/Python34-x64"
+    - python: "C:/Python34"
+    - python: "C:/Python35-x64"
+    - python: "C:/Python35"
 
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache
 
 init:
-  - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"
-  - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
+  - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:path
 install:
   # prepare pip
   - ps: python -m pip install --upgrade --no-binary wheel pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,4 +38,4 @@ install:
   - ps: pip freeze
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 test_script:
-  - nosetests -v --with-coverage --with-time ipykernel
+  - ps: nosetests -v --with-coverage --with-time ipykernel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,10 +21,14 @@ init:
   - ps: $Env:sdkverpath = "C:/Program Files/Microsoft SDKs/Windows/" + $Env:sdkver + "/Setup/WindowsSdkVer.exe"
   - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
 install:
+  # prepare pip
   - ps: python -m pip install --upgrade --no-binary wheel pip
   - ps: pip install --upgrade wheel
   - ps: pip --version
+  # install package
   - ps: pip install -e .
+  # install test requirements
+  - ps: pip install nose nose-timer coverage mock
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 test_script:
   - nosetests --with-coverage --with-time --coverage-package ipykernel ipykernel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,12 @@ environment:
       sdkver: "v7.0"
 
 matrix:
-   allow_failures:
-   - sdkver: "v7.0"
+  allow_failures:
+  - python: "C:/Python27-x64"
+    sdkver: "v7.0"
+
+  - python: "C:/Python27"
+    sdkver: "v7.0"
 
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,15 +15,6 @@ environment:
     - python: "C:/Python35-x64"
     - python: "C:/Python35"
 
-matrix:
-  allow_failures:
-    - python: "C:/Python27-x64"
-    - python: "C:/Python27"
-    - python: "C:/Python34-x64"
-    - python: "C:/Python34"
-    - python: "C:/Python35-x64"
-    - python: "C:/Python35"
-
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,4 +31,4 @@ install:
   - ps: pip install nose nose-timer coverage mock nose_warnings_filters
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 test_script:
-  - nosetests --with-coverage --with-time ipykernel
+  - nosetests -v --with-coverage --with-time ipykernel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
 
   global:
     distutils_use_sdk: 1
+    NOSE_COVER_PACKAGE: "ipykernel"
 
   matrix:
     - python: "C:/Python27-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ environment:
     - python: "C:/Python34"
     - python: "C:/Python35-x64"
     - python: "C:/Python35"
+    - python: "C:/Python36-x64"
+    - python: "C:/Python36"
 
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   # install package
   - ps: pip install -e .
   # install test requirements
-  - ps: pip install nose nose-timer coverage mock
+  - ps: pip install nose nose-timer coverage mock nose_warnings_filters
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 test_script:
   - nosetests --with-coverage --with-time --coverage-package ipykernel ipykernel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   # install package
   - ps: pip install -e .
   # install test requirements
-  - ps: pip install nose nose-timer coverage mock nose_warnings_filters numpy matplotlib
+  - ps: pip install -r test-requirements.txt
   # show current setup
   - ps: pip freeze
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,4 +38,4 @@ install:
   - ps: pip freeze
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 test_script:
-  - ps: nosetests -v --with-coverage --with-time ipykernel
+  - cmd: nosetests -v --with-coverage --with-time ipykernel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,10 @@ environment:
     - python: "C:/Python27-x64"
       sdkver: "v7.0"
 
+matrix:
+   allow_failures:
+   - sdkver: "v7.0"
+
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,9 @@ environment:
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache
 
+matix:
+  fast_finish: True
+
 init:
   - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:path
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,6 @@ environment:
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache
 
-matrix:
-  fast_finish: true
-
 init:
   - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:path
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,8 @@ install:
   - ps: pip install -e .
   # install test requirements
   - ps: pip install nose nose-timer coverage mock nose_warnings_filters numpy matplotlib
+  # show current setup
+  - ps: pip freeze
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 test_script:
   - nosetests -v --with-coverage --with-time ipykernel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,4 +30,4 @@ install:
   - ps: pip install nose nose-timer coverage mock nose_warnings_filters
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 test_script:
-  - nosetests --with-coverage --with-time --coverage-package ipykernel ipykernel
+  - nosetests --with-coverage --with-time ipykernel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,13 +14,15 @@ environment:
     - python: "C:/Python27"
       sdkver: "v7.0"
 
+    - python: "C:/Python34-x64"
+      sdkver: "v7.1"
+
+    - python: "C:/Python34"
+      sdkver: "v7.1"
+
 matrix:
   allow_failures:
-  - python: "C:/Python27-x64"
-    sdkver: "v7.0"
-
-  - python: "C:/Python27"
-    sdkver: "v7.0"
+  -  sdkver: "v7.0"
 
 cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,16 +26,18 @@ matrix:
 init:
   - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:path
 install:
-  # prepare pip
   - ps: python -m pip install --upgrade --no-binary wheel pip
   - ps: pip install --upgrade wheel
   - ps: pip --version
-  # install package
+
   - ps: pip install -e .
-  # install test requirements
+
   - cmd: pip install -r test-requirements.txt
-  # show current setup
   - ps: pip freeze
+
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 test_script:
-  - cmd: nosetests -v --with-coverage --with-time ipykernel
+  - cmd: coverage run -p -m nose.core -v --with-timer --timer-top-n 10 ipykernel
+on_success:
+  - ps: pip install codecov
+  - ps: codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
   # install package
   - ps: pip install -e .
   # install test requirements
-  - ps: pip install -r test-requirements.txt
+  - cmd: pip install -r test-requirements.txt
   # show current setup
   - ps: pip freeze
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,6 @@ cache:
 
 init:
   - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"
-  - ps: $Env:sdkverpath = "C:/Program Files/Microsoft SDKs/Windows/" + $Env:sdkver + "/Setup/WindowsSdkVer.exe"
   - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
 install:
   # prepare pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+build: false
+shallow_clone: true
+
+environment:
+
+  global:
+    distutils_use_sdk: 1
+
+  matrix:
+    - python: "C:/Python27-x64"
+      sdkver: "v7.0"
+
+    - python: "C:/Python27-x64"
+      sdkver: "v7.0"
+
+cache:
+  - C:\Users\appveyor\AppData\Local\pip\Cache
+
+init:
+  - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"
+  - ps: $Env:sdkverpath = "C:/Program Files/Microsoft SDKs/Windows/" + $Env:sdkver + "/Setup/WindowsSdkVer.exe"
+  - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
+install:
+  - ps: python -m pip install --upgrade --no-binary wheel pip
+  - ps: pip install --upgrade wheel
+  - ps: pip --version
+  - ps: pip install -e .
+  - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
+test_script:
+  - nosetests --with-coverage --with-time --coverage-package ipykernel ipykernel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   # install package
   - ps: pip install -e .
   # install test requirements
-  - ps: pip install nose nose-timer coverage mock nose_warnings_filters
+  - ps: pip install nose nose-timer coverage mock nose_warnings_filters numpy matplotlib
   - ps: python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 test_script:
   - nosetests -v --with-coverage --with-time ipykernel

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -199,11 +199,14 @@ def test_save_history():
 @dec.skip_without('faulthandler')
 def test_smoke_faulthandler():
     with kernel() as kc:
+        # Note: faulthandler.register is not available on windows.
         code = u'\n'.join([
-            'import faulthandler, signal',
+            'import sys',
+            'import faulthandler',
+            'import signal',
             'faulthandler.enable()',
-            'faulthandler.register(signal.SIGTERM)',
-        ])
+            'if not sys.platform.startswith("win32"):',
+            '    faulthandler.register(signal.SIGTERM)'])
         _, reply = execute(code, kc=kc)
         print(_)
         nt.assert_equal(reply['status'], 'ok', reply.get('traceback', ''))

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -6,7 +6,6 @@
 
 import io
 import os.path
-import pprint
 import sys
 import time
 
@@ -17,8 +16,9 @@ from ipython_genutils import py3compat
 from IPython.paths import locate_profile
 from ipython_genutils.tempdir import TemporaryDirectory
 
-from .utils import (new_kernel, kernel, TIMEOUT, assemble_output, execute,
-                    flush_channels, wait_for_idle)
+from .utils import (
+    new_kernel, kernel, TIMEOUT, assemble_output, execute,
+    flush_channels, wait_for_idle)
 
 
 def _check_master(kc, expected=True, stream="stdout"):
@@ -63,7 +63,7 @@ def test_sys_path_profile_dir():
         stdout, stderr = assemble_output(kc.iopub_channel)
         nt.assert_equal(stdout, "''\n")
 
-@dec.knownfailureif(sys.platform == 'win32', "subprocess prints fail on Windows")
+@dec.skipif(sys.platform == 'win32', "subprocess prints fail on Windows")
 def test_subprocess_print():
     """printing from forked mp.Process"""
     with new_kernel() as kc:
@@ -114,7 +114,7 @@ def test_subprocess_noprint():
         _check_master(kc, expected=True, stream="stderr")
 
 
-@dec.knownfailureif(sys.platform == 'win32', "subprocess prints fail on Windows")
+@dec.skipif(sys.platform == 'win32', "subprocess prints fail on Windows")
 def test_subprocess_error():
     """error in mp.Process doesn't crash"""
     with new_kernel() as kc:

--- a/ipykernel/tests/test_kernel.py
+++ b/ipykernel/tests/test_kernel.py
@@ -208,7 +208,6 @@ def test_smoke_faulthandler():
             'if not sys.platform.startswith("win32"):',
             '    faulthandler.register(signal.SIGTERM)'])
         _, reply = execute(code, kc=kc)
-        print(_)
         nt.assert_equal(reply['status'], 'ok', reply.get('traceback', ''))
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,8 @@
+nose
+nose-timer
+coverage
+mock
+nose_warnings_filters
+numpy
+matplotlib
+faulthandler ; python_version < "3"


### PR DESCRIPTION
This PR setups appveyor builds for python 2.7, 3.4, 3.5, 3.6

In more detail:

- Setup ci builds for appveyor.
- Use skip instead for knownfailureif, which requires a special runner.
- Use coverage directly instead of the nose-coverage plugin.
- Do not include test code into coverage report (more accurate coverage calculation).
- The faulthandler smoke test is updated for windows

Please note that builds are against released versions of dependencies.